### PR TITLE
Apply default styles to `body` only

### DIFF
--- a/technarium.css
+++ b/technarium.css
@@ -1,9 +1,8 @@
-html, body, div {
+body {
         background:#ffffff;
         padding:0px;
         margin:0px;
         width:100%;
-
 
 /* Helvetica/Arial-based sans serif stack */
 font-family: Frutiger, "Frutiger Linotype", Univers, Calibri, "Gill Sans", "Gill Sans MT",  "Myriad Pro", Myriad, "DejaVu Sans Condensed",  "Liberation Sans","Nimbus Sans L", Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
A set of "default" styles was being applied to all of `html`, `body` and `div`.

This breaks plug-ins that use `div`s to create overlays, such as SakaKey (captures keys for keyboard-based navigation).

After this commit, the styles are only applied to `body`.

Fixes #1.